### PR TITLE
Make updateGainTxt more robust

### DIFF
--- a/new_rtlsdr_source/src/main.cpp
+++ b/new_rtlsdr_source/src/main.cpp
@@ -240,7 +240,6 @@ public:
             //config.conf["devices"][selectedDevName]["tunerAgc"] = tunerAgc;
             config.conf["devices"][selectedDevName]["gain"] = gainId;
         }
-        if (gainId >= gainList.size()) { gainId = gainList.size() - 1; }
         updateGainTxt();
 
         // Load config
@@ -1026,6 +1025,7 @@ private:
     }
 
     void updateGainTxt() {
+        if (gainId >= gainList.size()) { gainId = gainList.size() - 1; }
         sprintf(dbTxt, "%.1f dB", (float)gainList[gainId] / 10.0f);
     }
 


### PR DESCRIPTION
For a reason not investigated, at startup only, updateGainTxt gets called with gainId = 21 when gainList.size() = 16.
Moving the check into updateGainTxt prevents a SIGABRT caused by an out of bounds error on the vector gainList.